### PR TITLE
fix open api spec errors and allow incrementing keys

### DIFF
--- a/safrs/config.py
+++ b/safrs/config.py
@@ -1,5 +1,9 @@
 # The suffix of the url path parameter shown in the swagger UI, eg Id => /Users/{UserId}
-OBJECT_ID_SUFFIX = 'Id'
+import os
+
+OBJECT_ID_SUFFIX = os.environ.get('OBJECT_ID_SUFFIX', None)
+if not OBJECT_ID_SUFFIX:
+    OBJECT_ID_SUFFIX = 'Id'
 
 #
 # The following URL fromatters determine the urls of the API resource objects
@@ -11,7 +15,9 @@ OBJECT_ID_SUFFIX = 'Id'
 RESOURCE_URL_FMT = '{}/{}/'
 INSTANCE_URL_FMT = RESOURCE_URL_FMT + '<string:{}' + OBJECT_ID_SUFFIX + '>/'
 # last parameter for the "method" urls below will be the method name
-INSTANCEMETHOD_URL_FMT = RESOURCE_URL_FMT + '<string:{}>/{}'
+INSTANCEMETHOD_URL_FMT = os.environ.get('INSTANCEMETHOD_URL_FMT', None)
+if not INSTANCEMETHOD_URL_FMT:
+    INSTANCEMETHOD_URL_FMT = RESOURCE_URL_FMT + '<string:{}>/{}'
 # (eg. /Users/get_list)
 CLASSMETHOD_URL_FMT = RESOURCE_URL_FMT + '{}'
 
@@ -41,4 +47,10 @@ USE_API_METHODS = True
 
 # ENABLE_RELATIONSHIPS enables relationships to be included.
 # This may slow down certain queries if the relationships are not properly configured!
-ENABLE_RELATIONSHIPS = True
+ENABLE_RELATIONSHIPS = bool(os.environ.get('ENABLE_RELATIONSHIPS', None))
+if not ENABLE_RELATIONSHIPS:
+    ENABLE_RELATIONSHIPS = True
+
+AUTOINCREMENT_IDS = bool(os.environ.get('AUTOINCREMENT_IDS', None))
+if not AUTOINCREMENT_IDS:
+    AUTOINCREMENT_IDS = False

--- a/safrs/jsonapi.py
+++ b/safrs/jsonapi.py
@@ -278,9 +278,9 @@ class Api(FRSApiBase):
                 operation, definitions_ = Extractor.extract(operation)
                 path_item[method] = operation
                 definitions.update(definitions_)
-                summary = parse_method_doc(f, operation)
-                if summary:
-                    operation['summary'] = summary.replace('<br/>','')
+                # summary = parse_method_doc(f, operation)
+                # if summary:
+                #     operation['summary'] = summary.replace('<br/>','')
 
 
         validate_definitions_object(definitions)


### PR DESCRIPTION
Hi,

This pull request contains three parts.
1) Removing white spaces from definitions in the swagger doc
2) Add AUTOINCREMENT_IDS setting in the scenario where the primary keys are integers using auto incrementation in the db. In this case we don't want to create a uuid in python as the db will create an id automatically (this is my scenario using postgres serial constraint).
3) I changed the config to read env variables so that someone can change the config without having to clone the repo and make changes to config.py directly.

let me know what you think, I am still relatively new to making prs.

Simon