### PR TITLE
Fix duplicate initialization of logger

### DIFF
--- a/safrs/__init__.py
+++ b/safrs/__init__.py
@@ -37,9 +37,7 @@ class SAFRS(object):
         db = cls.db = app_db
 
         if app.config.get('DEBUG', False):
-            cls.LOGLEVEL = logging.DEBUG
-
-        log = cls.init_logging(SAFRS.LOGLEVEL)
+            LOGGER.setLevel(logging.DEBUG)
 
         app.url_map.strict_slashes = False
         app.json_encoder = SAFRSJSONEncoder


### PR DESCRIPTION
- Only call `init_logging(level)` once on module load