### PR TITLE
hounour prefix argument

### DIFF
--- a/safrs/__init__.py
+++ b/safrs/__init__.py
@@ -58,7 +58,7 @@ def SAFRSAPI(app, host="localhost", port=5000, prefix="", description="SAFRSAPI"
     api = Api(
         app,
         api_spec_url="/swagger",
-        host=host,
+        host="%s:%s"%(host, port),
         custom_swagger=custom_swagger,
         description=description,
         decorators=decorators,

--- a/safrs/__init__.py
+++ b/safrs/__init__.py
@@ -62,7 +62,8 @@ def SAFRSAPI(app, host="localhost", port=5000, prefix="", description="SAFRSAPI"
         custom_swagger=custom_swagger,
         description=description,
         decorators=decorators,
-        prefix="",
+        prefix=prefix,
+        base_path=prefix
     )
 
     @app.before_request
@@ -114,10 +115,11 @@ class SAFRS:
         if app.config.get("DEBUG", False):
             LOGGER.setLevel(logging.DEBUG)
 
+
         # Register the API blueprint
         swaggerui_blueprint = kwargs.get("swaggerui_blueprint", None)
         if swaggerui_blueprint is None:
-            swaggerui_blueprint = get_swaggerui_blueprint(prefix, "/swagger.json")
+            swaggerui_blueprint = get_swaggerui_blueprint(prefix, "%s/swagger.json"%(prefix))
             app.register_blueprint(swaggerui_blueprint, url_prefix=prefix)
             swaggerui_blueprint.json_encoder = JSONEncoder
 

--- a/safrs/jsonapi.py
+++ b/safrs/jsonapi.py
@@ -87,7 +87,7 @@ def jsonapi_sort(object_query, safrs_object):
             else:
                 attr = getattr(safrs_object, sort_attr, None)
             if attr is None or not sort_attr in safrs_object._s_jsonapi_attrs:
-                log.error("Invalid sort column {}".format(sort_attr))
+                safrs.log.error("Invalid sort column {}".format(sort_attr))
                 continue
             object_query = object_query.order_by(attr)
 
@@ -144,7 +144,7 @@ def paginate(object_query, SAFRSObject=None):
     if count is None:
         count = object_query.count()
         if count > get_config('MAX_TABLE_COUNT'):
-            log.warning("Large table count detected, performance may be impacted, consider using '_s_count'")
+            safrs.log.warning("Large table count detected, performance may be impacted, consider using '_s_count'")
 
     first_args = (0, limit)
     last_args = (int(int(count / limit) * limit), limit)  # round down


### PR DESCRIPTION
he prefix argument used to only serve the swagger ui, but the requests would map to /${ModelName}, the swagger.json would be rooted at / and so on.
with this change we actually root all of the API related stuff in prefix:
     - ${prefix}/swagger.json
     - ['GET', 'POST', 'PATCH'] -> ${prefix}/${ModelName}…

we also fix a bug where the API port was wrong.

I couldn't figure out how to run the tests