### PR TITLE
Pull requirements.txt contents directly rather than with parse_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,8 @@ twine upload dist/*
 
 from distutils.core import setup
 
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
-install_requires = [str(ir.req) for ir in parse_requirements("requirements.txt", session=False)]
+with open("requirements.txt", "rt") as fp:
+    install_requires = fp.read().strip().split("\n")
 
 version = "2.8.0"
 


### PR DESCRIPTION
This PR addresses the following issues:

- #63 Changes the way `requirements.txt` is parsed in `setup.py` for compatibility with current and future versions of `pip`.