### PR TITLE
Skip type coercion on JSON columns

### DIFF
--- a/safrs/__init__.py
+++ b/safrs/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa: F401
 #
 # The code implements some seemingly awkward constructs and redundant functionality
 # This is however required for backwards compatibility, we'll get rid of it eventually

--- a/safrs/_api.py
+++ b/safrs/_api.py
@@ -2,6 +2,7 @@
 flask_restful_swagger2 API subclass
 """
 import copy
+from http import HTTPStatus
 import logging
 import werkzeug
 from flask_restful import abort
@@ -355,8 +356,6 @@ class Api(FRSApiBase):
                         # Add the sort, filter parameters to the swagger doc when retrieving a collection
                         #
                         if method == "get" and not (exposing_instance or is_jsonapi_rpc):
-                            relationship = getattr(resource.SAFRSObject, "relationship", None)
-
                             # limit parameter specifies the number of items to return
                             parameters += default_paging_parameters()
 
@@ -365,7 +364,7 @@ class Api(FRSApiBase):
 
                             parameters += list(resource.get_swagger_filters())
 
-                        if not (parameter.get("in") == "path" and not object_id in swagger_url) and parameter not in parameters:
+                        if not (parameter.get("in") == "path" and object_id not in swagger_url) and parameter not in parameters:
                             # Only if a path param is in path url then we add the param
                             parameters.append(parameter)
 
@@ -393,7 +392,7 @@ class Api(FRSApiBase):
                 # Check whether we manage to convert to json
                 try:
                     json.dumps(self._swagger_object)
-                except Exception as exc:
+                except Exception:
                     safrs.log.critical("Json encoding failed for")
                     # safrs.log.debug(self._swagger_object)
 
@@ -529,4 +528,3 @@ def http_method_decorator(fun):
         abort(status_code, errors=[errors])
 
     return method_wrapper
-

--- a/safrs/base.py
+++ b/safrs/base.py
@@ -147,7 +147,7 @@ class SAFRSBase(Model):
         instance = cls._s_query.filter_by(**primary_keys).one_or_none()
         if not instance:
             instance = object.__new__(cls)
-        
+
         return instance
 
     def __init__(self, *args, **kwargs):
@@ -236,7 +236,7 @@ class SAFRSBase(Model):
             safrs.DB.session.add(instance)
             try:
                 safrs.DB.session.commit()
-            except sqlalchemy.exc.SQLAlchemyError as exc: # pragma: no cover
+            except sqlalchemy.exc.SQLAlchemyError as exc:  # pragma: no cover
                 # Exception may arise when a db constraint has been violated
                 # (e.g. duplicate key)
                 safrs.log.warning(str(exc))
@@ -259,9 +259,9 @@ class SAFRSBase(Model):
             :param **attributes:
         """
         for attr_name, attr_val in attributes.items():
-            if not attr_name in self.__class__._s_jsonapi_attrs:
+            if attr_name not in self.__class__._s_jsonapi_attrs:
                 continue
-            value = self._s_parse_attr_value(attr_name, attr_val)
+            _ = self._s_parse_attr_value(attr_name, attr_val)
             # check if write permission is set
             if self._s_check_perm(attr_name, "w"):
                 setattr(self, attr_name, attr_val)
@@ -421,7 +421,7 @@ class SAFRSBase(Model):
             id = item
         try:
             primary_keys = cls.id_type.get_pks(id)
-        except AttributeError: # pragma: no cover
+        except AttributeError:  # pragma: no cover
             # This happens when we request a sample from a class that is not yet loaded
             # when we're creating the swagger models
             safrs.log.debug('AttributeError for class "{}"'.format(cls.__name__))
@@ -430,7 +430,7 @@ class SAFRSBase(Model):
         if id is not None or not failsafe:
             try:
                 instance = cls._s_query.filter_by(**primary_keys).first()
-            except Exception as exc: # pragma: no cover
+            except Exception as exc:  # pragma: no cover
                 raise GenericError("get_instance : {}".format(exc))
 
             if not instance and not failsafe:
@@ -553,7 +553,7 @@ class SAFRSBase(Model):
                     result[attr] = json.loads(json.dumps(attr_val, cls=current_app.json_encoder))
                 else:
                     result[attr] = attr_val
-            except UnicodeDecodeError as exc:  # pragma: no cover
+            except UnicodeDecodeError:  # pragma: no cover
                 safrs.log.warning("UnicodeDecodeError fetching {}.{}".format(self, attr))
                 result[attr] = ""
             except Exception as exc:
@@ -637,7 +637,7 @@ class SAFRSBase(Model):
         """
         if property_name.startswith("_"):
             return False
-            
+
         for rel in cls.__mapper__.relationships:
             if rel.key != property_name:
                 continue
@@ -837,9 +837,9 @@ class SAFRSBase(Model):
             try:
                 sample_id = sample.jsonapi_id
                 return sample_id
-            except Exception as exc:
-                log.warning("Failed to retrieve sample id for {}".format(cls))
-        
+            except Exception:
+                safrs.log.warning("Failed to retrieve sample id for {}".format(cls))
+
         sample_id = cls.id_type.sample_id(cls)
         return sample_id
 
@@ -1064,7 +1064,7 @@ class Included:
                 continue
             try:
                 result.append(instance._s_jsonapi_encode())
-            except sqlalchemy.orm.exc.DetachedInstanceError as exc:
+            except sqlalchemy.orm.exc.DetachedInstanceError:
                 # todo: test this
                 continue
 

--- a/safrs/base.py
+++ b/safrs/base.py
@@ -335,6 +335,10 @@ class SAFRSBase(Model):
             safrs.log.debug(exc)
             return attr_val
 
+        # skip type coercion on JSON columns, since they could be anything
+        if type(attr.type) is sqlalchemy.sql.sqltypes.JSON:
+            return attr_val
+
         """
             Parse datetime and date values for some common representations
             If another format is uses, the user should create a custom column type or custom serialization

--- a/safrs/jsonapi.py
+++ b/safrs/jsonapi.py
@@ -28,8 +28,7 @@ import sqlalchemy
 import sqlalchemy.orm.dynamic
 import sqlalchemy.orm.collections
 from sqlalchemy.orm.interfaces import MANYTOONE
-from flask import make_response, url_for, request
-from flask import jsonify
+from flask import jsonify, make_response, url_for, request
 from flask_restful_swagger_2 import Resource as FRSResource
 import safrs
 from .base import SAFRSBase, is_jsonapi_attr, Included
@@ -581,7 +580,7 @@ class SAFRSRestAPI(Resource):
                 if not isinstance(item, dict):
                     raise ValidationError("Invalid Data Object")
                 instance = self._patch_instance(item)
-            response = make_response({}, HTTPStatus.CREATED)
+            response = make_response(jsonify({}), HTTPStatus.CREATED)
 
         elif not data or not isinstance(data, dict):
             raise ValidationError("Invalid Data Object")
@@ -698,7 +697,7 @@ class SAFRSRestAPI(Resource):
                 safrs.log.warning("Client sent a bulk POST but did not specify the bulk extension")
             for item in data:
                 instance = self._create_instance(item)
-            resp_data = {}
+            resp_data = jsonify({})
             location = None
         else:
             instance = self._create_instance(data)
@@ -1017,7 +1016,7 @@ class SAFRSRestRelationshipAPI(Resource):
             response = make_response(obj_data, HTTPStatus.OK)
         else:
             # Nothing changed, reflect the data
-            response = make_response({"data": data}, HTTPStatus.OK)
+            response = make_response(jsonify({"data": data}), HTTPStatus.OK)
 
         return response
 

--- a/safrs/safrs_api.py
+++ b/safrs/safrs_api.py
@@ -176,6 +176,7 @@ def test_decorator(func):
 
     return func
 
+
 #
 # DB and logging initialization
 #

--- a/safrs/safrs_types.py
+++ b/safrs/safrs_types.py
@@ -156,7 +156,7 @@ class SAFRSID:
         if len(cls.columns) == 1:
             try:
                 result = cls.columns[0].type.python_type(id)
-            except Exception as exc:
+            except Exception:
                 raise ValidationError("Invalid id: '{}'.".format(id))
         else:
             safrs.log.debug("ID Validation not implemented")
@@ -203,7 +203,7 @@ class SAFRSID:
                     result[col_name] = pk_col.default
                 else:
                     result[col_name] = ""
-            except:
+            except Exception:
                 result[col_name] = ""
 
         return result
@@ -223,7 +223,7 @@ class SAFRSID:
         sample = obj.query.first()
         if sample:
             return sample.jsonapi_id
-    
+
         return "jsonapi_id_string"
 
 

--- a/safrs/swagger_doc.py
+++ b/safrs/swagger_doc.py
@@ -44,8 +44,7 @@ def parse_object_doc(object):
     except (SyntaxError, yaml.scanner.ScannerError) as exc:
         safrs.log.error("Failed to parse documentation {} ({})".format(raw_doc, exc))
         yaml_doc = {"description": raw_doc}
-
-    except Exception as exc:
+    except Exception:
         raise ValidationError("Failed to parse api doc")
 
     if isinstance(yaml_doc, dict):
@@ -536,7 +535,7 @@ def swagger_method_doc(cls, method_name, tags=None):
         """
             decorator
         """
-        method = getattr(cls,method_name,None)
+        method = getattr(cls, method_name, None)
         method_doc = parse_object_doc(method)
         class_name = cls.__name__
         if tags is None:
@@ -548,9 +547,9 @@ def swagger_method_doc(cls, method_name, tags=None):
         if is_debug():
             responses.update(debug_responses)
 
-        summary = method_doc.get("summary","Invoke {}.{}".format(class_name, method_name))
+        summary = method_doc.get("summary", "Invoke {}.{}".format(class_name, method_name))
         description = method_doc.get("description", summary)
-        
+
         doc = {
             "tags": doc_tags,
             "description": description,

--- a/safrs/util.py
+++ b/safrs/util.py
@@ -47,4 +47,3 @@ def classproperty(func):
         func = classmethod(func)
 
     return ClassPropertyDescriptor(func)
-


### PR DESCRIPTION
In this PR:

- #66 Stop trying to coerce type on `JSON` columns to `dict` since there could be really any data type in there.
- Fix a bug where `make_response` being called with an empty dict `{}` as a param, causing an exception.
- Some (hopefully non-controversial) flake8 linting.